### PR TITLE
Add OpenBSD support.

### DIFF
--- a/src/datadir.h
+++ b/src/datadir.h
@@ -10,6 +10,8 @@ Copyright (C) 1999-2018 David Joffe
 #define _DATADIR_H_
 
 //! Data directory [dj2017-08 should this move to config.h?]
+#ifndef DATA_DIR
 #define DATA_DIR "data/"
+#endif
 
 #endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2014,7 +2014,7 @@ bool HeroIsHurting()
 void DrawHealth()
 {
 	// Build a string representing health bars (which are in the 8x8 font)
-	char szHealth[MAX_HEALTH+1]={0};
+	unsigned char szHealth[MAX_HEALTH+1]={0};
 	for ( unsigned int i=0; i<MAX_HEALTH; ++i )
 	{
 		// 170 = health; 169 = not health

--- a/src/sdl/djsound.cpp
+++ b/src/sdl/djsound.cpp
@@ -13,7 +13,7 @@ Copyright (C) 1999-2018 David Joffe and Kent Mein
 #include <SDL_mixer.h>
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>//Fixing malloc.h 'not found' error compiling on Mac [dj2016-10]
 #else
 #include <malloc.h>

--- a/src/sys_defs.h
+++ b/src/sys_defs.h
@@ -21,7 +21,7 @@ extern "C"
 #include <stdarg.h>
 #include <stddef.h>
 #include <string.h>
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>//Fixing malloc.h 'not found' error compiling on Mac [dj2016-10]
 #else
 #include <malloc.h>


### PR DESCRIPTION
Hi! This pull request adds OpenBSD support for gnukem.
It also does the following:
* Allows the user to specify a different DATA_DIR on the command line without triggering a warning.
* Squashes a warning in which some characters >127 were being wrapped around to negative.

There will soon be an official OpenBSD package of gnukem.
Thanks!